### PR TITLE
Add Identity Plus EU endpoint

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -15,7 +15,7 @@ sites:
       - 200
       - 201
     headers:
-      - "OTS-VIA: upptime"
+      - "ONETIME-VIA: upptime"
   - name: API Status (v1)
     url: https://onetimesecret.com/api/v1/status
     __dangerous__body_down_if_text_missing: '"status":"nominal"'
@@ -27,9 +27,12 @@ sites:
       - "Content-Type: application/x-www-form-urlencoded"
       - "OTS-VIA: upptime"
     body: 'secret=$UNIQUE_TESTABLE_VALUE&ttl=86400'
-  - name: Shared Platform
-    url: https://shared.onetimesecret.com/
-
+  - name: Identity Plus (EU)
+    url: https://eu.onetimesecret.com/
+    maxResponseTime: 5000
+    expectedStatusCodes:
+      - 200
+      - 201
 
 # Delay (in milliseconds) that will occur between checking each
 # configured endpoint. Default: 0.


### PR DESCRIPTION
This pull request includes several commits that enhance our service monitoring coverage. The deprecated Shared Platform endpoint has been removed, and the Identity Plus EU endpoint has been added with specific configurations. Additionally, the expected status codes have been adjusted for better accuracy. These changes align with our current infrastructure and improve our monitoring capabilities.