### PR TITLE
Add New Zealand site to monitoring

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -56,6 +56,12 @@ sites:
     expectedStatusCodes:
       - 200
       - 201
+  - name: Identity Plus (NZ)
+    url: https://nz.onetimesecret.com/
+    maxResponseTime: 5000
+    expectedStatusCodes:
+      - 200
+      - 201
 
 # Delay (in milliseconds) that will occur between checking each
 # configured endpoint. Default: 0.


### PR DESCRIPTION
Added nz.onetimesecret.com to the list of monitored sites following the same configuration pattern as other Identity Plus regions.